### PR TITLE
(#16) Hitbox and placed unit status components and grid factory

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
@@ -5,12 +5,11 @@ import com.badlogic.gdx.math.GridPoint2;
 import com.csse3200.game.areas.terrain.TerrainFactory;
 import com.csse3200.game.areas.terrain.TerrainFactory.TerrainType;
 import com.csse3200.game.entities.Entity;
-import com.csse3200.game.entities.factories.ObstacleFactory;
+import com.csse3200.game.entities.factories.GridFactory;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.components.gamearea.GameAreaDisplay;
 import com.csse3200.game.ui.DragAndDropDemo;
-import com.csse3200.game.utils.math.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +51,8 @@ public class LevelGameArea extends GameArea{
         displayUI();
 
         spawnMap();
-        spawnTiles();
+        float scale = 1.4f;
+        spawnTiles(scale);
         testUI_1();
 
         testUI_2();
@@ -154,17 +154,18 @@ public class LevelGameArea extends GameArea{
         music.play();
     }
 
-    private void spawnTiles() {
+    private void spawnTiles(float scale) {
         for (int i = 0; i < 50; i++) {
             Entity tile;
+            float tileX = (float) (2.9 + scale * (i % 10));
+            float tileY = (float) (1.45 + scale * (i / 10));
+            // logic for alternating tile images
             if ((i / 10) % 2 == 1) {
-                tile = ObstacleFactory.createTile(i % 2);
+                tile = GridFactory.createTile(i % 2, scale, tileX, tileY);
             } else {
-                tile = ObstacleFactory.createTile(1- (i % 2));
+                tile = GridFactory.createTile(1- (i % 2), scale, tileX, tileY);
             }
-            //need to make scale dynamic to screen size
-            float scale = 1.4F;
-            tile.setPosition((float) (2.9 + scale * (i % 10)), (float) (1.45 + scale * (i / 10)));
+            tile.setPosition(tileX, tileY);
             spawnEntity(tile);
         }
     }

--- a/source/core/src/main/com/csse3200/game/components/tile/TileHitboxComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/tile/TileHitboxComponent.java
@@ -1,0 +1,60 @@
+package com.csse3200.game.components.tile;
+
+import com.badlogic.gdx.math.GridPoint2;
+import com.csse3200.game.components.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A component that is used the hitbox calculations of the tiles
+ */
+public class TileHitboxComponent extends Component {
+    private static final Logger logger = LoggerFactory.getLogger(TileHitboxComponent.class);
+    private float maxPosX;
+    private float maxPosY;
+    private float minPosX;
+    private float minPosY;
+
+    public TileHitboxComponent(float maxPosX, float maxPosY, float minPosX, float minPosY) {
+        this.maxPosX = maxPosX;
+        this.maxPosY = maxPosY;
+        this.minPosX = minPosX;
+        this.minPosY = minPosY;
+    }
+
+    public float getMaxPosX() {
+        return maxPosX;
+    }
+
+    public float getMaxPosY() {
+        return maxPosY;
+    }
+
+    public float getMinPosX() {
+        return minPosX;
+    }
+
+    public float getMinPosY() {
+        return minPosY;
+    }
+
+    public void setMaxPosX(float maxPosX) {
+        this.maxPosX = maxPosX;
+    }
+
+    public void setMaxPosY(float maxPosY) {
+        this.maxPosY = maxPosY;
+    }
+
+    public void setMinPosX(float minPosX) {
+        this.minPosX = minPosX;
+    }
+
+    public void setMinPosY(float minPosY) {
+        this.minPosY = minPosY;
+    }
+
+    public boolean inTileHitbox(GridPoint2 pos) {
+        return pos.x > minPosX && pos.x < maxPosX && pos.y > minPosY && pos.y < maxPosY;
+    }
+}

--- a/source/core/src/main/com/csse3200/game/components/tile/TileStorageComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/tile/TileStorageComponent.java
@@ -1,0 +1,47 @@
+package com.csse3200.game.components.tile;
+
+import com.csse3200.game.components.Component;
+import com.csse3200.game.entities.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A component that is used to track the status of the unit placed on a tile,
+ * it is also used for adding and removing the units from the tile.
+ */
+public class TileStorageComponent extends Component {
+    private static final Logger logger = LoggerFactory.getLogger(TileStorageComponent.class);
+    private Entity TileUnit;
+
+    public TileStorageComponent() {
+        this.TileUnit = null;
+    }
+
+    /**
+     * Gets the unit that is currently on the tile
+     * @return The unit currently on the tile or null if not unit is stored
+     */
+    public Entity getTileUnit() {
+        return this.TileUnit;
+    }
+
+    /**
+     * Adds a unit to the tile
+     * @param unit the unit to be added
+     */
+    public void addTileUnit(Entity unit) {
+        if (TileUnit == null) {
+            this.TileUnit = unit;
+            logger.debug("Unit {} has been added to this tile", unit);
+        } else {
+            logger.debug("Tile has unit already.");
+        }
+    }
+
+    /**
+     * Removes the unit from the tile
+     */
+    public void removeTileUnit() {
+        this.TileUnit = null;
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/GridFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/GridFactory.java
@@ -1,0 +1,42 @@
+package com.csse3200.game.entities.factories;
+
+import com.csse3200.game.components.tile.TileHitboxComponent;
+import com.csse3200.game.components.tile.TileStorageComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.rendering.TextureRenderComponent;
+
+/**
+ * This factory creates the grid and the tiles in the grid.
+ */
+public class GridFactory {
+
+
+    /**
+     * Creates a tile entity
+     * @param imageStatus used to determine what image to use for the tile
+     * @param scale the scale for the size of the tile
+     * @param x the x value for the new tile
+     * @param y the y value for the new tile
+     * @return the newly created tile
+     */
+    public static Entity createTile(int imageStatus, float scale, float x, float y) {
+        String image_path = "images/olive_tile.png";
+        if (imageStatus == 1) {
+            image_path = "images/green_tile.png";
+        }
+        // need to figure out how to get min and max x and y values of the tile
+        Entity tile =
+                new Entity()
+                        .addComponent(new TextureRenderComponent(image_path))
+                        .addComponent(new TileHitboxComponent(x, y, x, y))
+                        .addComponent(new TileStorageComponent());
+
+        tile.getComponent(TextureRenderComponent.class).scaleEntity();
+        tile.scaleHeight(scale);
+        return tile;
+    }
+
+    private GridFactory() {
+        throw new IllegalStateException("Instantiating static util class");
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/ObstacleFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/ObstacleFactory.java
@@ -33,25 +33,6 @@ public class ObstacleFactory {
     return tree;
   }
 
-  public static Entity createTile(int status) {
-      String image_path = "images/olive_tile.png";
-      if (status == 1) {
-          image_path = "images/green_tile.png";
-      }
-      Entity tile =
-              new Entity()
-                      .addComponent(new TextureRenderComponent(image_path))
-                      .addComponent(new PhysicsComponent())
-                      .addComponent(new ColliderComponent().setLayer(PhysicsLayer.OBSTACLE));
-
-      tile.getComponent(PhysicsComponent.class).setBodyType(BodyType.StaticBody);
-      tile.getComponent(TextureRenderComponent.class).scaleEntity();
-      tile.scaleHeight(1.4f);
-      // tile.scaleWidth(1.3f);
-      // PhysicsUtils.setScaledCollider(tile, 0.5f, 0.2f);
-      return tile;
-  }
-
   /**
    * Creates an invisible physics wall.
    * @param width Wall width in world units


### PR DESCRIPTION
# Description

Added components for handling the adding and removing units to tiles and the hitbox of the tiles (for checking which tile to place a unit). Also added a new factory for all grid related activities.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
