### PR TITLE
Currency UI — Sunlight HUD

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
@@ -5,7 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
-/** 左上角显示“阳光”数值，只读取 Currency，不做计算。 */
+
 public class SunlightHudDisplay extends UIComponent {
   private final Currency currency;
   private Table table;
@@ -25,7 +25,7 @@ public class SunlightHudDisplay extends UIComponent {
   @Override public void update() { refresh(); }
 
   private void refresh() {
-    int amount = currency.getSunlight();   // 读 Currency.java 里的 getter
+    int amount = currency.getSunlight();   
     label.setText("☀ " + amount);
   }
 
@@ -33,6 +33,6 @@ public class SunlightHudDisplay extends UIComponent {
 
    @Override
   public void draw(SpriteBatch batch) {
-    // 这里什么都不用画；Stage 已经负责绘制 label/table 了
+
   }
 }

--- a/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
@@ -1,0 +1,32 @@
+package com.csse3200.game.components.currency;
+
+import com.csse3200.game.ui.UIComponent;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+
+/** 左上角显示“阳光”数值，只读取 Currency，不做计算。 */
+public class SunlightHudDisplay extends UIComponent {
+  private final Currency currency;
+  private Table table;
+  private Label label;
+
+  public SunlightHudDisplay(Currency currency) { this.currency = currency; }
+
+  @Override public void create() {
+    super.create();
+    table = new Table(); table.setFillParent(true); table.top().left();
+    label = new Label("☀ 0", skin);
+    table.add(label).padTop(10f).padLeft(10f);
+    stage.addActor(table);
+    refresh();
+  }
+
+  @Override public void update() { refresh(); }
+
+  private void refresh() {
+    int amount = currency.getSunlight();   // 读 Currency.java 里的 getter
+    label.setText("☀ " + amount);
+  }
+
+  @Override public void dispose() { table.remove(); super.dispose(); }
+}

--- a/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
@@ -3,6 +3,7 @@ package com.csse3200.game.components.currency;
 import com.csse3200.game.ui.UIComponent;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
 /** 左上角显示“阳光”数值，只读取 Currency，不做计算。 */
 public class SunlightHudDisplay extends UIComponent {
@@ -29,4 +30,9 @@ public class SunlightHudDisplay extends UIComponent {
   }
 
   @Override public void dispose() { table.remove(); super.dispose(); }
+
+   @Override
+  public void draw(SpriteBatch batch) {
+    // 这里什么都不用画；Stage 已经负责绘制 label/table 了
+  }
 }

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -27,8 +27,10 @@ import com.csse3200.game.ui.terminal.Terminal;
 import com.csse3200.game.ui.terminal.TerminalDisplay;
 import com.csse3200.game.components.maingame.MainGameExitDisplay;
 import com.csse3200.game.components.gamearea.PerformanceDisplay;
+import com.csse3200.game.components.currency.SunlightHudDisplay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * The game screen containing the main game.
@@ -78,6 +80,9 @@ public class MainGameScreen extends ScreenAdapter {
     Texture sunTex = ServiceLocator.getResourceService().getAsset("images/normal_sunlight.png", Texture.class);
     spawnSun(stage, sunTex, 300, 200, 25);
     spawnSun(stage, sunTex, 520, 340, 25);
+    Entity ui = new Entity().addComponent(new SunlightHudDisplay(currency));
+    ServiceLocator.getEntityService().register(ui);
+
   }
 
   @Override


### PR DESCRIPTION
## What & Why
Add a simple HUD in the top-left corner that displays the current sun (currency) amount.
Per team split, this PR is **UI only** — no counting logic and no click detection.
The HUD just reads the shared Currency instance.

## Changes
- New UI component `SunlightHudDisplay` that renders a label on the top-left.
- Hooks the HUD into `MainGameScreen`, passing the existing `currency` instance.
- Updates the label every frame by reading `Currency#getSunlight()`.
- Implements `draw(SpriteBatch)` as required by `UIComponent` (no custom drawing; Stage handles it).

## Files
- `source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java` (new)
- `source/core/src/main/com/csse3200/game/screens/MainGameScreen.java` (register HUD)

## How to Test
1. Run the game and enter the main scene.
2. Wait for sun to spawn / collect some sun.
3. Verify the top-left HUD shows `☀ <amount>` and updates as the amount changes.

## Impact / Risk
- UI-only; does not modify gameplay logic.
- Uses the existing shared `Currency` instance, so it reflects whatever the game systems produce.

## Follow-ups (nice to have)
- Replace per-frame polling with an event/callback (e.g., OnSunChanged).
- Add icon asset + thousand separators for readability.
- Small “fly to HUD” pickup animation.
