### PR TITLE
feat(ui): sunlight HUD icon + black label; remove Health row

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/currency/SunlightHudDisplay.java
@@ -1,38 +1,91 @@
 package com.csse3200.game.components.currency;
 
-import com.csse3200.game.services.ServiceLocator;
-import com.csse3200.game.ui.UIComponent;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.csse3200.game.ui.UIComponent;
+import com.csse3200.game.services.CurrencyService;
+import com.csse3200.game.services.ResourceService;
+import com.csse3200.game.services.ServiceLocator;
 
-
+/**
+ * 左上角“阳光”HUD：太阳图标 + 数字。
+ * 通过 CurrencyService 读取当前阳光数量。
+ */
 public class SunlightHudDisplay extends UIComponent {
+
+  private transient CurrencyService currencyService;
+  private transient ResourceService resources;
+
   private Table table;
-  private Label label;
+  private Label amountLabel;
 
-  public SunlightHudDisplay() {}
+  @Override
+public void create() {
+  super.create();
 
-  @Override public void create() {
-    super.create();
-    table = new Table(); table.setFillParent(true); table.top().left();
-    label = new Label("☀ 0", skin);
-    table.add(label).padTop(10f).padLeft(10f);
-    stage.addActor(table);
-    refresh();
+  // 1) service
+  ResourceService resources = ServiceLocator.getResourceService();
+  CurrencyService currencyService = ServiceLocator.getCurrencyService();
+
+  // 2) 贴图（太阳图标）
+  Texture sunTex = resources.getAsset("images/normal_sunlight.png", Texture.class);
+  Image sunIcon = new Image(sunTex);
+  sunIcon.setSize(22f, 22f);
+
+  // 3) 数字（不用 skin，直接用默认字体）
+  Label.LabelStyle style = new Label.LabelStyle(new BitmapFont(), Color.BLACK);
+  amountLabel = new Label(String.valueOf(currencyService.get()), style);
+  amountLabel.setFontScale(3f);
+
+  // 4) 左上角布局
+  table = new Table();
+  table.setFillParent(true);
+  table.top().left().padTop(48f).padLeft(14f);
+  table.add(sunIcon).padRight(6f);
+  table.add(amountLabel);
+
+  Stage stage = ServiceLocator.getRenderService().getStage();
+  stage.addActor(table);
+}
+
+    
+ @Override
+public void update() {
+  CurrencyService cs = ServiceLocator.getCurrencyService();
+  amountLabel.setText(String.valueOf(cs.get()));
+}
+
+
+
+  // Scene2D 走 Stage 渲染，这里不需要自己画
+  @Override
+  public void draw(SpriteBatch batch) { }
+
+  @Override
+  public void dispose() {
+    if (table != null) {
+      table.remove();
+      table = null;
+    }
+    super.dispose();
   }
 
-  @Override public void update() { refresh(); }
-
-  private void refresh() {
-    int amount = ServiceLocator.getCurrencyService().get();
-    label.setText("☀ " + amount);
-  }
-
-  @Override public void dispose() { table.remove(); super.dispose(); }
-
-   @Override
-  public void draw(SpriteBatch batch) {
+  /** 保险地拿当前阳光值（服务可能还没准备好时不崩） */
+  private int safeGetSun() {
+    if (currencyService == null) {
+      try {
+        currencyService = ServiceLocator.getCurrencyService();
+      } catch (Exception ignored) {}
+    }
+    // 你们的服务里方法名若不是 getSunlight()，改成真实的方法名
+   return currencyService != null ? currencyService.get() : 0;
+// 或者：return currencyService != null ? currencyService.getCurrency().getSunlight() : 0;
 
   }
 }

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
@@ -14,8 +14,7 @@ import com.csse3200.game.ui.UIComponent;
  */
 public class PlayerStatsDisplay extends UIComponent {
   Table table;
-  private Image heartImage;
-  private Label healthLabel;
+
 
   /**
    * Creates reusable ui styles and adds actors to the stage.
@@ -25,7 +24,6 @@ public class PlayerStatsDisplay extends UIComponent {
     super.create();
     addActors();
 
-    entity.getEvents().addListener("updateHealth", this::updatePlayerHealthUI);
   }
 
   /**
@@ -38,17 +36,6 @@ public class PlayerStatsDisplay extends UIComponent {
     table.setFillParent(true);
     table.padTop(45f).padLeft(5f);
 
-    // Heart image
-    float heartSideLength = 30f;
-    heartImage = new Image(ServiceLocator.getResourceService().getAsset("images/heart.png", Texture.class));
-
-    // Health text
-    int health = entity.getComponent(CombatStatsComponent.class).getHealth();
-    CharSequence healthText = String.format("Health: %d", health);
-    healthLabel = new Label(healthText, skin, "large");
-
-    table.add(heartImage).size(heartSideLength).pad(5);
-    table.add(healthLabel);
     stage.addActor(table);
   }
 
@@ -57,19 +44,5 @@ public class PlayerStatsDisplay extends UIComponent {
     // draw is handled by the stage
   }
 
-  /**
-   * Updates the player's health on the ui.
-   * @param health player health
-   */
-  public void updatePlayerHealthUI(int health) {
-    CharSequence text = String.format("Health: %d", health);
-    healthLabel.setText(text);
-  }
 
-  @Override
-  public void dispose() {
-    super.dispose();
-    heartImage.remove();
-    healthLabel.remove();
-  }
 }

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MainGameScreen extends ScreenAdapter {
   private static final Logger logger = LoggerFactory.getLogger(MainGameScreen.class);
-  private static final String[] mainGameTextures = {"images/heart.png", "images/normal_sunlight.png"};
+  private static final String[] mainGameTextures = {"images/normal_sunlight.png"};
   private static final Vector2 CAMERA_POSITION = new Vector2(7.5f, 7.5f);
 
   private final GdxGame game;
@@ -72,6 +72,10 @@ public class MainGameScreen extends ScreenAdapter {
     loadAssets();
     createUI();
 
+    Entity uiHud = new Entity().addComponent(new SunlightHudDisplay());
+    ServiceLocator.getEntityService().register(uiHud);
+
+
     logger.debug("Initialising main game screen entities");
     TerrainFactory terrainFactory = new TerrainFactory(renderer.getCamera());
     ForestGameArea forestGameArea = new ForestGameArea(terrainFactory);
@@ -81,8 +85,6 @@ public class MainGameScreen extends ScreenAdapter {
     Texture sunTex = ServiceLocator.getResourceService().getAsset("images/normal_sunlight.png", Texture.class);
     spawnSun(stage, sunTex, 300, 200, 25);
     spawnSun(stage, sunTex, 520, 340, 25);
-    Entity ui = new Entity().addComponent(new SunlightHudDisplay());
-    ServiceLocator.getEntityService().register(ui);
 
   }
 


### PR DESCRIPTION
### Summary

* Add **sunlight HUD** to the top-left: **sun icon + black numeric label**.
* Label value is read **live from `CurrencyService`**.
* **Remove the “Health” row** from the HUD (per new requirement).

### Changes

* `SunlightHudDisplay`: renders icon and number; updates from `CurrencyService`.
* `MainGameScreen`: ensures `images/normal_sunlight.png` is loaded via `mainGameTextures`.
* Minor UI layout/skin adjustments for readability.

### Assets

* `assets/images/normal_sunlight.png` (already added and loaded).

### How to Test

1. Launch the desktop client.
2. Verify top-left shows the **sun icon** with a **black number**.
3. Pick up/spawn currency; confirm the number **increments in real time**.
4. Confirm the **Health** line is **no longer shown**.

### Screenshots

*Add a screenshot of the HUD showing the sun icon and number.*

### Notes / Impact

* No gameplay logic changed beyond HUD display.
* Backed by `CurrencyService`; other UI can reuse the same service.

---

