### PR TITLE
new: Adds javadoc build step on PR into main so that teams don't have…

### DIFF
--- a/.github/workflows/javadoc_build.yaml
+++ b/.github/workflows/javadoc_build.yaml
@@ -1,4 +1,4 @@
-name: Build Javadoc (Doesn't publish this)
+name: Javadoc Test Build
 
 # Run this only on PRs into main so team's know that Javadoc publish won't fail
 # Don't want to waste gh runner minutes either.


### PR DESCRIPTION
Simple build step so main doesn't break because of javadoc.