### PR TITLE
Task/stat changing animations

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
@@ -958,7 +958,6 @@ public class LevelGameArea extends GameArea implements AreaAPI, EnemySpawner {
       } else {
         // healer entity, no scrap & kills itself after one animation cycle
         logger.info("Healer placed");
-        healDefences();
         // remove the healer after its animation
         ServiceLocator.getRenderService()
             .getStage()


### PR DESCRIPTION
# Description

This PR re-adds functionality which was overwritten due to issues with the auto-merge from main in the original PR (#422).  In particular, it adds back missing animation triggers in the `healDefences()` function in LevelGameArea.
Fixes #422 and closes #421 

## Type of change

- [ ] Bug fix


# How Has This Been Tested?
This has been tested via visually checking that the functionality has been restored.  If you want to view the functionality:

- [ ] Enter level 4 with a healer entity.  Place as many defence entities as desired (e.g. slingshooters) followed by the healer.  Confirm that the "hp-up" animation plays above all defence entities except healers.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
