### PR TITLE
Bug/gun bot projectile

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/LevelGameArea.java
@@ -313,29 +313,32 @@ public class LevelGameArea extends GameArea implements AreaAPI, EnemySpawner {
           .addListener(
               ENTITY_DEATH_EVENT,
               () -> {
-                  Timer.schedule(new Timer.Task(){
+                Timer.schedule(
+                    new Timer.Task() {
                       @Override
-                      public void run(){
-                          spawnEffect(
-                                  ServiceLocator.getResourceService()
-                                          .getAsset("images/effects/shell_explosion.atlas", TextureAtlas.class),
-                                  "shell_explosion",
-                                  new Vector2[] {damageTile, damageTile}, // effect stays in place
-                                  (int) tileSize, // scale to match tile size
-                                  new float[] {0.05f, 0.5f}, // frame duration & total effect time
-                                  Animation.PlayMode.NORMAL,
-                                  false, // not moving
-                                  false);
-                          damageRobotsAtPosition(
-                                  damageTile,
-                                  tileSize,
-                                  wall.getComponent(DefenderStatsComponent.class).getBaseAttack());
-                          knockbackRobotsAtPosition(knockbackTile, 3);
-                          knockbackRobotsAtPosition(knockbackTile2, 3);
-                          requestDespawn(wall);
-                          robots.remove(wall);
+                      public void run() {
+                        spawnEffect(
+                            ServiceLocator.getResourceService()
+                                .getAsset(
+                                    "images/effects/shell_explosion.atlas", TextureAtlas.class),
+                            "shell_explosion",
+                            new Vector2[] {damageTile, damageTile}, // effect stays in place
+                            (int) tileSize, // scale to match tile size
+                            new float[] {0.05f, 0.5f}, // frame duration & total effect time
+                            Animation.PlayMode.NORMAL,
+                            false, // not moving
+                            false);
+                        damageRobotsAtPosition(
+                            damageTile,
+                            tileSize,
+                            wall.getComponent(DefenderStatsComponent.class).getBaseAttack());
+                        knockbackRobotsAtPosition(knockbackTile, 3);
+                        knockbackRobotsAtPosition(knockbackTile2, 3);
+                        requestDespawn(wall);
+                        robots.remove(wall);
                       }
-                  }, 0f);
+                    },
+                    0f);
               });
 
       spawnEntity(wall);
@@ -811,14 +814,16 @@ public class LevelGameArea extends GameArea implements AreaAPI, EnemySpawner {
         .addListener(
             "attack",
             (Entity target) -> {
-              if(!despawned[0]) {
-                  despawned[0] = true;
-                  Timer.schedule(new Timer.Task() {
+              if (!despawned[0]) {
+                despawned[0] = true;
+                Timer.schedule(
+                    new Timer.Task() {
                       @Override
-                      public void run(){
-                          requestDespawn(projectile);
+                      public void run() {
+                        requestDespawn(projectile);
                       }
-                  }, 0f);
+                    },
+                    0f);
               }
             });
 
@@ -827,14 +832,16 @@ public class LevelGameArea extends GameArea implements AreaAPI, EnemySpawner {
         .addListener(
             DESPAWN_SLINGSHOT_EVENT,
             projectileEntity -> {
-              if(!despawned[0]) {
-                  despawned[0] = true;
-                  Timer.schedule(new Timer.Task() {
+              if (!despawned[0]) {
+                despawned[0] = true;
+                Timer.schedule(
+                    new Timer.Task() {
                       @Override
-                      public void run(){
-                          requestDespawn(projectile);
+                      public void run() {
+                        requestDespawn(projectile);
                       }
-                  }, 0f);
+                    },
+                    0f);
               }
             });
 
@@ -843,14 +850,16 @@ public class LevelGameArea extends GameArea implements AreaAPI, EnemySpawner {
         .addListener(
             "despawn",
             () -> {
-              if(!despawned[0]) {
-                  despawned[0] = true;
-                  Timer.schedule(new Timer.Task() {
+              if (!despawned[0]) {
+                despawned[0] = true;
+                Timer.schedule(
+                    new Timer.Task() {
                       @Override
-                      public void run(){
-                          requestDespawn(projectile);
+                      public void run() {
+                        requestDespawn(projectile);
                       }
-                  }, 0f);
+                    },
+                    0f);
               }
             });
 

--- a/source/core/src/main/com/csse3200/game/components/projectiles/MoveLeftComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/projectiles/MoveLeftComponent.java
@@ -16,11 +16,11 @@ public class MoveLeftComponent extends Component {
   }
 
   @Override
-  public void create(){
-      physicsComponent = entity.getComponent(PhysicsComponent.class);
-      if(physicsComponent != null){
-          physicsComponent.getBody().setLinearVelocity(-speed, 0);
-      }
+  public void create() {
+    physicsComponent = entity.getComponent(PhysicsComponent.class);
+    if (physicsComponent != null) {
+      physicsComponent.getBody().setLinearVelocity(-speed, 0);
+    }
   }
 
   @Override


### PR DESCRIPTION
# GunBot Projectile despawning and Damage Mapping 

The projectile of the gun bot is now despawning after collision with defences and is mapping the damage.
Also, added the debug input command for skipping the wave using F5 key.

Fixes / Closes # (issue)
#363 
#409 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
