### PR TITLE
Revert back to ChangeListeners for display settings select boxes

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/settingsmenu/DisplaySettingsMenu.java
+++ b/source/core/src/main/com/csse3200/game/components/settingsmenu/DisplaySettingsMenu.java
@@ -1,8 +1,10 @@
 package com.csse3200.game.components.settingsmenu;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.csse3200.game.persistence.Settings;
 import com.csse3200.game.services.ServiceLocator;
@@ -70,9 +72,9 @@ public class DisplaySettingsMenu extends UIComponent {
 
     // Add change listener to show/hide resolution row based on display mode
     displayModeSelect.addListener(
-        new ClickListener() {
+        new ChangeListener() {
           @Override
-          public void clicked(InputEvent event, float x, float y) {
+          public void changed(ChangeEvent event, Actor actor) {
             String selectedMode = displayModeSelect.getSelected();
             boolean isWindowed = "WINDOWED".equals(selectedMode);
             resolutionLabel.setVisible(isWindowed);
@@ -100,9 +102,9 @@ public class DisplaySettingsMenu extends UIComponent {
 
     // Add change listener to apply resolution change immediately
     resolutionSelect.addListener(
-        new ClickListener() {
+        new ChangeListener() {
           @Override
-          public void clicked(InputEvent event, float x, float y) {
+          public void changed(ChangeEvent event, Actor actor) {
             applyResolutionChange();
           }
         });


### PR DESCRIPTION
# Description

Tiny PR to revert listener change in DisplaySettingsMenu made in previous PR #439 that caused unexpected behaviour of no longer updating display mode (fullscreen, windowed etc) immediately. This PR changes the select box listeners in that file only back to ChangeListeners.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Visual testing

- [x] Previously tested since this PR is reverting a recent change

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] My changes generate no new warnings

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
