### PR TITLE
Fix/pan crash

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/settingsmenu/DisplaySettingsMenu.java
+++ b/source/core/src/main/com/csse3200/game/components/settingsmenu/DisplaySettingsMenu.java
@@ -1,8 +1,10 @@
 package com.csse3200.game.components.settingsmenu;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.csse3200.game.persistence.Settings;
 import com.csse3200.game.services.ServiceLocator;
@@ -70,9 +72,9 @@ public class DisplaySettingsMenu extends UIComponent {
 
     // Add change listener to show/hide resolution row based on display mode
     displayModeSelect.addListener(
-        new ClickListener() {
+        new ChangeListener() {
           @Override
-          public void clicked(InputEvent event, float x, float y) {
+          public void changed(ChangeEvent event, Actor actor) {
             String selectedMode = displayModeSelect.getSelected();
             boolean isWindowed = "WINDOWED".equals(selectedMode);
             resolutionLabel.setVisible(isWindowed);
@@ -100,9 +102,9 @@ public class DisplaySettingsMenu extends UIComponent {
 
     // Add change listener to apply resolution change immediately
     resolutionSelect.addListener(
-        new ClickListener() {
+        new ChangeListener() {
           @Override
-          public void clicked(InputEvent event, float x, float y) {
+          public void changed(ChangeEvent event, Actor actor) {
             applyResolutionChange();
           }
         });


### PR DESCRIPTION
# Description

Fixes a crash caused when the camera pan logic at the start of a level tried to clamp a value with min > max. Fix checks if this would occur and if so skips the wave preview completely. Also added a check to ensure the block on unit placement during the preview is not triggered if the preview is skipped.

I also took the opportunity to update the switch statement and add a final to one of the variables to squash some sonar cloud issues while I was there.

Fixes / Closes #477 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Gameplay tests to confirm:

- [x] Pan still occurs on normal resolutions
- [x] Pan is skipped and crash does not occur on ultra wide monitor

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
